### PR TITLE
Rename Login scene to Get Followers and modify GetFollowersView initi…

### DIFF
--- a/App/GitHub/GitHub.xcodeproj/project.pbxproj
+++ b/App/GitHub/GitHub.xcodeproj/project.pbxproj
@@ -11,14 +11,14 @@
 		1A51042924296D4700B0130A /* Commons.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA4811A240A060C0086B6BB /* Commons.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1A51042A24296D4700B0130A /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA4811B240A060C0086B6BB /* Core.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		1A51042B24296D4700B0130A /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1AA4811B240A060C0086B6BB /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		1A9E540E2429368900B9585A /* LoginViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E540D2429368900B9585A /* LoginViewControllerTests.swift */; };
+		1A9E540E2429368900B9585A /* GetFollowersViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E540D2429368900B9585A /* GetFollowersViewControllerTests.swift */; };
 		1A9E5410242946C600B9585A /* GitHubUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9E540F242946C600B9585A /* GitHubUITests.swift */; };
 		1AA48124240A08E50086B6BB /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA48123240A08E50086B6BB /* MainCoordinator.swift */; };
-		1AA48126240A6BE10086B6BB /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA48125240A6BE10086B6BB /* LoginView.swift */; };
+		1AA48126240A6BE10086B6BB /* GetFollowersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA48125240A6BE10086B6BB /* GetFollowersView.swift */; };
 		1AA48130240C71440086B6BB /* Localized.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1AA4812F240C71440086B6BB /* Localized.strings */; };
 		1AE20C112407390200867692 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE20C102407390200867692 /* AppDelegate.swift */; };
 		1AE20C132407390200867692 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE20C122407390200867692 /* SceneDelegate.swift */; };
-		1AE20C152407390200867692 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE20C142407390200867692 /* LoginViewController.swift */; };
+		1AE20C152407390200867692 /* GetFollowersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE20C142407390200867692 /* GetFollowersViewController.swift */; };
 		1AE20C1A2407390300867692 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1AE20C192407390300867692 /* Assets.xcassets */; };
 		1AE20C1D2407390300867692 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1AE20C1B2407390300867692 /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
@@ -56,17 +56,17 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		1A9E540D2429368900B9585A /* LoginViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewControllerTests.swift; sourceTree = "<group>"; };
+		1A9E540D2429368900B9585A /* GetFollowersViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFollowersViewControllerTests.swift; sourceTree = "<group>"; };
 		1A9E540F242946C600B9585A /* GitHubUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubUITests.swift; sourceTree = "<group>"; };
 		1AA4811A240A060C0086B6BB /* Commons.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Commons.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AA4811B240A060C0086B6BB /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AA48123240A08E50086B6BB /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
-		1AA48125240A6BE10086B6BB /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		1AA48125240A6BE10086B6BB /* GetFollowersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFollowersView.swift; sourceTree = "<group>"; };
 		1AA4812F240C71440086B6BB /* Localized.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localized.strings; sourceTree = "<group>"; };
 		1AE20C0D2407390200867692 /* GitHub.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GitHub.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1AE20C102407390200867692 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1AE20C122407390200867692 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		1AE20C142407390200867692 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		1AE20C142407390200867692 /* GetFollowersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFollowersViewController.swift; sourceTree = "<group>"; };
 		1AE20C192407390300867692 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1AE20C1C2407390300867692 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1AE20C1E2407390300867692 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -120,13 +120,13 @@
 			path = Coordinator;
 			sourceTree = "<group>";
 		};
-		1AA48122240A08780086B6BB /* Login */ = {
+		1AA48122240A08780086B6BB /* Get Followers */ = {
 			isa = PBXGroup;
 			children = (
-				1AE20C142407390200867692 /* LoginViewController.swift */,
-				1AA48125240A6BE10086B6BB /* LoginView.swift */,
+				1AE20C142407390200867692 /* GetFollowersViewController.swift */,
+				1AA48125240A6BE10086B6BB /* GetFollowersView.swift */,
 			);
-			path = Login;
+			path = "Get Followers";
 			sourceTree = "<group>";
 		};
 		1AE20C042407390200867692 = {
@@ -164,7 +164,7 @@
 			isa = PBXGroup;
 			children = (
 				1AE20C292407390400867692 /* Info.plist */,
-				1A9E540D2429368900B9585A /* LoginViewControllerTests.swift */,
+				1A9E540D2429368900B9585A /* GetFollowersViewControllerTests.swift */,
 			);
 			path = GitHubTests;
 			sourceTree = "<group>";
@@ -201,7 +201,7 @@
 		1AE20C4224073D8C00867692 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
-				1AA48122240A08780086B6BB /* Login */,
+				1AA48122240A08780086B6BB /* Get Followers */,
 				1AA48121240A08640086B6BB /* Coordinator */,
 			);
 			path = Scenes;
@@ -340,10 +340,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1AE20C152407390200867692 /* LoginViewController.swift in Sources */,
+				1AE20C152407390200867692 /* GetFollowersViewController.swift in Sources */,
 				1AA48124240A08E50086B6BB /* MainCoordinator.swift in Sources */,
 				1AE20C112407390200867692 /* AppDelegate.swift in Sources */,
-				1AA48126240A6BE10086B6BB /* LoginView.swift in Sources */,
+				1AA48126240A6BE10086B6BB /* GetFollowersView.swift in Sources */,
 				1AE20C132407390200867692 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -352,7 +352,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1A9E540E2429368900B9585A /* LoginViewControllerTests.swift in Sources */,
+				1A9E540E2429368900B9585A /* GetFollowersViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/App/GitHub/GitHub/Scenes/Coordinator/MainCoordinator.swift
+++ b/App/GitHub/GitHub/Scenes/Coordinator/MainCoordinator.swift
@@ -26,7 +26,7 @@ class MainCoordinator: Coordinator {
     ///   - window: The host __UIWindow__ that holds `navigationController` as  `rootViewController`
     init(navigationController: UINavigationController, window: UIWindow) {
         self.navigationController = navigationController
-        window.rootViewController = LoginViewController()
+        window.rootViewController = GetFollowersViewController()
         window.makeKeyAndVisible()
     }
     
@@ -43,7 +43,7 @@ class MainCoordinator: Coordinator {
     // MARK: - Navigation
     
     private func goToLogin() {
-        let viewController = LoginViewController()
+        let viewController = GetFollowersViewController()
         viewController.view.backgroundColor = .white
         navigationController?.pushViewController(viewController, animated: false)
     }

--- a/App/GitHub/GitHub/Scenes/Get Followers/GetFollowersView.swift
+++ b/App/GitHub/GitHub/Scenes/Get Followers/GetFollowersView.swift
@@ -1,5 +1,5 @@
 //
-//  LoginView.swift
+//  GetFollowersView.swift
 //  GitHub
 //
 //  Created by José Victor Pereira Costa on 29/02/20.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public final class LoginView: UIView {
+public final class GetFollowersView: UIView {
     
     // MARK: - Action closures
     
@@ -16,9 +16,9 @@ public final class LoginView: UIView {
     
     // MARK: - Initializers
     
-    init() {
-        super.init(frame: .zero)
-        setUpSubviews()
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUp()
     }
     
     required init?(coder: NSCoder) {
@@ -61,7 +61,7 @@ public final class LoginView: UIView {
     
     // MARK: - Constraints setup
     
-    func setUpSubviews() {
+    func setUp() {
         setUpLogoImageView()
         setUpUsernameTextField()
         setUpGetFollowersButton()

--- a/App/GitHub/GitHub/Scenes/Get Followers/GetFollowersViewController.swift
+++ b/App/GitHub/GitHub/Scenes/Get Followers/GetFollowersViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  GetFollowersViewController.swift
 //  GitHub
 //
 //  Created by José Victor Pereira Costa on 26/02/20.
@@ -9,22 +9,22 @@
 import UIKit
 import Commons
 
-protocol LoginService {
+protocol GetFollowersService {
     func singUp(with user: String)
 }
 
-class LoginViewController: UIViewController {
+class GetFollowersViewController: UIViewController {
     
     // MARK: - Properties
     
-    var service: LoginService?
+    var service: GetFollowersService?
     
     lazy var onGetFollowersButtonTapped: ((String) -> Void) = { [unowned self] userName in
         self.service?.singUp(with: userName)
     }
     
-    lazy var loginView: LoginView = {
-        let view = LoginView()
+    lazy var getFollowersView: GetFollowersView = {
+        let view = GetFollowersView()
         view.getFollowersButtonTapped = onGetFollowersButtonTapped
         return view
     }()
@@ -33,7 +33,7 @@ class LoginViewController: UIViewController {
     
     override func loadView() {
         super.loadView()
-        view = loginView
+        view = getFollowersView
     }
     
 }

--- a/App/GitHub/GitHubTests/GetFollowersViewControllerTests.swift
+++ b/App/GitHub/GitHubTests/GetFollowersViewControllerTests.swift
@@ -1,5 +1,5 @@
 //
-//  LoginViewControllerTests.swift
+//  GetFollowersViewControllerTests.swift
 //  GitHubTests
 //
 //  Created by José Victor Pereira Costa on 23/03/20.
@@ -9,23 +9,23 @@
 import XCTest
 @testable import GitHub
 
-class LoginViewControllerTests: XCTestCase {
+class GetFollowersViewControllerTests: XCTestCase {
 
     func testOnGetFollowersButtonTapped() {
-        let sut = LoginViewController()
-        
+        let sut = GetFollowersViewController()
+    
         var getFollowersTapped = false
-        let userName = "test"
+        let typedUsername = "test"
         var receivedUsername = ""
         sut.onGetFollowersButtonTapped = { userName in
             getFollowersTapped.toggle()
             receivedUsername = userName
         }
         
-        sut.loginView.getFollowersButtonTapped?(userName)
+        sut.getFollowersView.getFollowersButtonTapped?(typedUsername)
         
-        XCTAssert(getFollowersTapped, "The onGetFollowersButtonTapped should be called")
-        XCTAssertEqual(userName, receivedUsername)
+        XCTAssert(getFollowersTapped, "The get followers button should be tapped")
+        XCTAssertEqual(typedUsername, receivedUsername, "The received user name should be equal to typed username")
     }
     
     


### PR DESCRIPTION
…alizer.

The feature Login was renamed to Get Followers due to the correct feature responsibility.  In that way all the components were renamed:
	- GetFollowersView
	- GetFollowersViewController

The GetFollowersView's custom initializer was replaced to the original initializer implementation. This change avoids over-engineering.